### PR TITLE
Secutiry fix - verify API server SSL certificate

### DIFF
--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -290,7 +290,7 @@ class VyfakturujAPI{
         curl_setopt($curl,CURLOPT_FAILONERROR,FALSE);
         curl_setopt($curl,CURLOPT_HTTPAUTH,CURLAUTH_BASIC);
         curl_setopt($curl,CURLOPT_USERPWD,$this->login.':'.$this->apiHash);
-        curl_setopt($curl,CURLOPT_SSL_VERIFYPEER,false);
+        curl_setopt($curl,CURLOPT_SSL_VERIFYPEER,TRUE);
         curl_setopt($curl,CURLOPT_SSL_VERIFYHOST,2);
         curl_setopt($curl,CURLOPT_HTTPHEADER,array('Content-Type: application/json'));
 


### PR DESCRIPTION
Is very important to always verify API server's certificate. 

Is highly recommended use [ca-bundle](https://github.com/composer/ca-bundle#to-use-with-curl) directly in PHP code for peer verification.

If you have trouble to verify crt on API server, never stop checking certs (or never push it as officially library :)