### PR TITLE
Přidání enumeračních (výčtových) konstant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,12 @@
     "homepage": "https://www.vyfakturuj.cz/api/",
     "type": "library",
     "license": "MIT",
+    "authors": [
+        {
+           "name": "Redbit s.r.o.",
+            "homepage": "https://www.redbit.cz/"
+        }
+    ],
     "support": {
         "email": "info@vyfakturuj.cz"
     },

--- a/examples/02-invoice.php
+++ b/examples/02-invoice.php
@@ -16,6 +16,13 @@ $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 #
 #
 
+
+/*
+ * Některá čísla v příkladu níže jsou číselná označení systémových typů.
+ * Například: 'type' => 1 znamená, že vytvořený doklad bude Faktura a nikoliv třeba Výzva k platbě.
+ * Popis všech hodnot najdete v dokumentaci: https://vyfakturujcz.docs.apiary.io/#reference/faktury
+ * Zkušenější uživatelé mohou použít výčet možných hodnot v přiložené třídě VyfakturujEnum.
+ */
 $opt = array(
     'type' => 1,
     'calculate_vat' => 2,

--- a/examples/04-template.php
+++ b/examples/04-template.php
@@ -32,6 +32,12 @@ $contact = $vyfakturuj_api->createContact($opt_contact);    // vytvoříme nový
 
 $_ID_CONTACT = $contact['id'];
 
+/*
+ * Některá čísla v příkladu níže jsou číselná označení systémových typů.
+ * Například: 'type' => 2 znamená, že vytváříme Pravidelnou fakturu, nikoliv jen Šablonu.
+ * Popis všech hodnot najdete v dokumentaci: https://vyfakturujcz.docs.apiary.io/#reference/faktury
+ * Zkušenější uživatelé mohou použít výčet možných hodnot v přiložené třídě VyfakturujEnum.
+ */
 $opt_template = array(
     'id_customer' => $_ID_CONTACT,// vložíme právě vytvořený kontakt
 //    'id_customer' => 20224,// vložíme právě vytvořený kontakt

--- a/examples/05-invoice-sendMail.php
+++ b/examples/05-invoice-sendMail.php
@@ -18,6 +18,12 @@ $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 $_ID_DOKUMENTU = 51672;
 
+/*
+ * Některá čísla v příkladu níže jsou číselná označení systémových typů.
+ * Například: 'type' => 3 znamená, že posíláme Potvrzení o úhradě, nikoliv třeba Upomínku.
+ * Popis všech hodnot najdete v dokumentaci: https://vyfakturujcz.docs.apiary.io/#reference/faktury
+ * Zkušenější uživatelé mohou použít výčet možných hodnot v přiložené třídě VyfakturujEnum.
+ */
 $opt = array(// šablona, kterou si přejeme odeslat
     'type' => 3,
     'to' => 'demo@vyfakturuj.cz',// lze také použit tento zápis: 'demo1@vyfakturuj.cz, demo2@vyfakturuj.cz'

--- a/examples/09-invoice_search.php
+++ b/examples/09-invoice_search.php
@@ -4,6 +4,12 @@ include __DIR__ . '/00-config.php';
 
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
+/*
+ * Některá čísla v příkladu níže jsou číselná označení systémových typů.
+ * Například: 'flags' => 64 znamená, že hledáme doklady se přeplatkem vzniklým při uhrazení.
+ * Popis všech hodnot najdete v dokumentaci: https://vyfakturujcz.docs.apiary.io/#reference/faktury
+ * Zkušenější uživatelé mohou použít výčet možných hodnot v přiložené třídě VyfakturujEnum.
+ */
 $opt = array(
 //    'date_created_from' => '2016-10-01',
 //    'date_created_to' => '2016-10-31',

--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -1,11 +1,16 @@
 <?php
+/**
+ * @package Redbit\Vyfakturuj\VyfakturujAPI
+ * @license MIT
+ * @coypright 2016-2018 Redbit s.r.o.
+ * @author Redbit s.r.o. <info@vyfakturuj.cz>
+ * @author Ing. Martin Dostál
+ */
 
 
 
 /**
  * Třída pro práci s API Vyfakturuj.cz
- *
- * @author Ing. Martin Dostál <info@vyfakturuj.cz>
  */
 class VyfakturujAPI
 {

--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -6,7 +6,6 @@
  * Třída pro práci s API Vyfakturuj.cz
  *
  * @author Ing. Martin Dostál <info@vyfakturuj.cz>
- * @version 2.1.6
  */
 class VyfakturujAPI
 {

--- a/libs/VyfakturujEnum.class.php
+++ b/libs/VyfakturujEnum.class.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package Redbit\Vyfakturuj\VyfakturujAPI
+ * @license MIT
+ * @coypright 2016-2018 Redbit s.r.o.
+ * @author Redbit s.r.o. <info@vyfakturuj.cz>
+ * @author Ing. Martin Dostál
+ */
+
+
+/**
+ * Definice pomocných konstant
+ */
+class VyfakturujEnum
+{
+    // Invoice types (type)
+    const DOCUMENT_TYPE_FAKTURA = 1; // Faktura
+    const DOCUMENT_TYPE_ZALOHOVA_FAKTURA = 2; // Zálohová faktura
+    const DOCUMENT_TYPE_PROFORMA_FAKTURA = 4; // Proforma faktura
+    const DOCUMENT_TYPE_VYZVA_K_PLATBE = 8; // Výzva k platbě
+    const DOCUMENT_TYPE_DANOVY_DOKLAD = 16; // Daňový doklad
+    const DOCUMENT_TYPE_OPRAVNY_DANOVY_DOKLAD = 32; // Opravný daňový doklad
+    const DOCUMENT_TYPE_PRIJMOVY_DOKLAD = 64; // Příjmový doklad
+    const DOCUMENT_TYPE_OPRAVNY_DOKLAD = 128; // Opravný doklad
+    const DOCUMENT_TYPE_OBJEDNAVKA = 512; // Objednávka
+
+    // Invoice flags (flags)
+    const DOCUMENT_FLAG_IS_VAT_PAYER = 1; // Dokument obsahuje DPH
+    const DOCUMENT_FLAG_IS_PAID = 2; // Uhrazeno
+    const DOCUMENT_FLAG_IS_SENT = 4; // Odesláno e-mailem zákazníkovi
+    const DOCUMENT_FLAG_IS_STORNO = 8; // Doklad je stornován
+    const DOCUMENT_FLAG_IS_SENT_REMINDER = 16; // Odeslána e-mailem zákazníkovi upomínka
+    const DOCUMENT_FLAG_WARNING_OVERCHARGE = 32; // Přeplatek
+    const DOCUMENT_FLAG_WARNING_UNDERCHARGE = 64; // Nedoplatek
+    const DOCUMENT_FLAG_IS_DOWNLOADED_BY_ACCOUNTANT = 256; // Doklad byl stažen účetním
+
+    // Invoice EET status (eet_status)
+    const EET_STATE_NO_EET = 1; // Nevstupuje - doklad nesplňuje podmínky pro vstup do EET
+    const EET_STATE_NO_SEND = 2; // Neodesílat - při tisku dokladu nedojde k odeslání do EET
+    const EET_STATE_READY_TO_SEND = 4; // K odeslání - doklad je určen k odeslání do EET
+    const EET_STATE_EXTERNAL = 8; // Externě - záznam o tržbě evidovalo jiné zařízení
+    const EET_STATE_SENT_TO_EET = 16; // Odesláno - doklad byl odeslán do EET
+    const EET_STATE_SENT_ERROR = 32; // Chyba - nastala chyba při odeslání
+
+    // Payment methods (payment_method)
+    const PAYMENT_METHOD_BANK = 1; // Bankovní převod
+    const PAYMENT_METHOD_CASH = 2; // Hotovost
+    const PAYMENT_METHOD_CASHONDELIVERY = 4; // Dobírka
+    const PAYMENT_METHOD_ONLINECARD = 8; // Kartou online
+    const PAYMENT_METHOD_ADVANCE = 16; // Záloha
+    const PAYMENT_METHOD_CREDIT = 32; // Zápočet
+    const PAYMENT_METHOD_PAYPAL = 128; // PayPal
+
+    // VAT caclulate method (calculate_vat)
+    const VAT_CALC_METHOD_AMOUNT_WITHOUT_VAT = 1; // Položky jsou uvedeny jako základ daně
+    const VAT_CALC_METHOD_AMOUNT_WITH_VAT = 2; // Položky mají koncovou cenu s DPH
+    const VAT_CALC_METHOD_VAT_IS_IN_SPECIAL_MODE = 3; // DPH je účtováno ve speciálním režimu
+    const VAT_CALC_METHOD_REVERSE_CHARGE = 4; // DPH je v režimu prenesené daňové povinnosti
+    const VAT_CALC_METHOD_NOT_VATPAYER = 5; // Neplátce DPH
+
+    // Price rounding (round_invoice)
+    const PRICE_ROUND_NONE = 1; // Nezaokrouhlovat
+    const PRICE_ROUND_HALEROVE_VYROVNANI = 2; // Háleřové vyrovnání
+    const PRICE_ROUND_ZAOKROUHLIT_DPH = 3; // Zaokrouhlit DPH
+
+    // VAT rate (vat_rate_type)
+    const CAT_RATE_CUSTOM = 1; // Vlastní / historická
+    const CAT_RATE_BASE = 2; // Základní
+    const CAT_RATE_HIGH = 4; // Zvýšená
+    const CAT_RATE_LOW = 8; // Snížená
+    const CAT_RATE_LOW2 = 16; // Druhá snížená
+    const CAT_RATE_LOW3 = 32; // Nulová
+    const CAT_RATE_ZERO = 64; // Neplátce - není daň
+    const CAT_RATE_NULL = 128; // Třetí snížená
+
+    // Template type (type)
+    const TEMPLATE_TYPE_TEMPLATE = 1; // Šablona
+    const TEMPLATE_TYPE_REPEATED = 2; // Pravidelná faktura
+
+    // Repeated invoice start (start_type)
+    const SCHEDULE_START_TYPE_DATE = 1; // Přesné datum
+    const SCHEDULE_START_TYPE_FIRST = 2; // První den v měsíci
+    const SCHEDULE_START_TYPE_LAST = 4; // Poslední den v měsíci
+
+    // Repeated invoice end (end_type)
+    const SCHEDULE_END_TYPE_ALWAYS = 1; // Bez ukončení
+    const SCHEDULE_END_TYPE_UNTIL_DATE = 2; // Podle data
+    const SCHEDULE_END_TYPE_COUNT = 4; // Podle počtu dokladů
+    const SCHEDULE_END_TYPE_UNTIL_PAID = 8; // Zastavit při prvním neuhrazeném dokladu
+    const SCHEDULE_END_TYPE_STOP = 16; // Zastaveno (další se již nebudou generovat)
+
+    // Document type to send to mail (type)
+    const MAIL_SEND_TYPE_INVOICE = 1; // Nový doklad
+    const MAIL_SEND_TYPE_REMINDER = 2; // Upomínka
+    const MAIL_SEND_TYPE_IS_PAID = 3; // Doklad byl uhrazen
+}


### PR DESCRIPTION
> Toto závisí na #5 - nejdřív se musí mergnout ta

V kódu i v příkladech se pracuje pouze číselnou interpretací různých přepínačů.

BC: ne

Doplnil jsem sadu konstant, které odpovídají hodnotám v [dokumentaci](https://vyfakturujcz.docs.apiary.io/#) a upravil jsem příklady.

Původní zápis:
```php
$opt = array(
    'type' => 1,
    'calculate_vat' => 2,
    'payment_method' => 2
);
```

Nový zápis:
```php
$opt = array(
    'type' => VyfakturujEnum::DOCUMENT_TYPE_FAKTURA,
    'calculate_vat' => VyfakturujEnum::VAT_CALC_METHOD_AMOUNT_WITH_VAT,
    'payment_method' => VyfakturujEnum::PAYMENT_METHOD_CASH
);
```

Názvy konstant jsou většinou převzaty ze zdrojového kódu Vyfakturuj, ale nejsou 1:1 (drobné úpravy, stylystické i gramatické korekce). 