### PR TITLE
Vylepšení manutální instalace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Nainstalujte knihovnu pomocí Composeru (doporučujeme):
 ```shell
 composer require vyfakturuj/vyfakturuj-api-php
 ```
-Případně si můžete [stáhnout poslední verzi v ZIP souboru](https://github.com/vyfakturuj/vyfakturuj-api-php/releases/latest).
+a následně na začátek vašeho projektu (nejčastěji `index.php`) přidejte kód pro načtení závislostí:
+```php
+require __DIR__ . '/vendor/autoload.php';
+```
+
+Případně si můžete [stáhnout poslední verzi v ZIP souboru](manual-installation.md).
 
 Ve své aplikaci pak jednoduše vytvoříte objekt `VyfakturujAPI`:
 ```php

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ require __DIR__ . '/vendor/autoload.php';
 
 Případně si můžete [stáhnout poslední verzi v ZIP souboru](manual-installation.md).
 
+**Důležité:** Pokud ve svém projektu již používáte Vyfakturuj, nebo [SimpleShop](https://www.simpleshop.cz/)
+(např. [WordPress plugin](https://www.simpleshop.cz/category/wordpress-plugin/)), ujistěte se, že nemáte knihovnu
+v projektu vícekrát. 
+
 Ve své aplikaci pak jednoduše vytvoříte objekt `VyfakturujAPI`:
 ```php
 $vyfakturuj = new VyfakturujAPI('login', 'API klíč');

--- a/examples/00-config.php
+++ b/examples/00-config.php
@@ -1,7 +1,9 @@
 <?php
 
+// Načtení knihoven
+include __DIR__ . '/../simple-autoload.php';
+
+// Nastavení Vyfakturuj API
 define('VYFAKTURUJ_API_LOGIN', '');  // E-mail, kterým se přihlašujete do Vyfakturuj
 define('VYFAKTURUJ_API_KEY', '');    // API klíč, který najdete v Nastavení -> API
-
-include __DIR__ . '/../libs/VyfakturujAPI.class.php';
 

--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -2,7 +2,7 @@
 /**
  * @package Redbit\Vyfakturuj\VyfakturujAPI
  * @license MIT
- * @coypright 2016-2018 Redbit s.r.o.
+ * @copyright 2016-2018 Redbit s.r.o.
  * @author Redbit s.r.o. <info@vyfakturuj.cz>
  * @author Ing. Martin Dostál
  */

--- a/libs/VyfakturujEnum.class.php
+++ b/libs/VyfakturujEnum.class.php
@@ -2,7 +2,7 @@
 /**
  * @package Redbit\Vyfakturuj\VyfakturujAPI
  * @license MIT
- * @coypright 2016-2018 Redbit s.r.o.
+ * @copyright 2016-2018 Redbit s.r.o.
  * @author Redbit s.r.o. <info@vyfakturuj.cz>
  * @author Ing. Martin Dostál
  */

--- a/manual-installation.md
+++ b/manual-installation.md
@@ -1,0 +1,12 @@
+# Ruční instalace [PHP knihovny Vyfakturuj API](https://github.com/vyfakturuj/vyfakturuj-api-php)
+
+> **Doporučujeme, abyste namísto ruční instalace Vyfakturuj API využili [instalaci přes Composer](README.md#instalace)** 
+
+Pokud nemůžete nebo nechcete [istalovat tuto knihovnu přes Composer](README.md#instalace), můžete si
+stáhnout [poslední verzi v ZIP souboru](https://github.com/vyfakturuj/vyfakturuj-api-php/releases/latest).
+
+Tento ZIP rozbalte, tuto složku pak nahrajte do svého webu a následně na začátek vašeho projektu (nejčastěji `index.php`)
+přidejte kód pro načtení knihoven, přibližně v této podobě:
+```php
+require_once 'cesta-k-nahrane-slozce/simple-autoload.php';
+```

--- a/manual-installation.md
+++ b/manual-installation.md
@@ -2,7 +2,7 @@
 
 > **Doporučujeme, abyste namísto ruční instalace Vyfakturuj API využili [instalaci přes Composer](README.md#instalace)** 
 
-Pokud nemůžete nebo nechcete [istalovat tuto knihovnu přes Composer](README.md#instalace), můžete si
+Pokud nemůžete nebo nechcete [instalovat tuto knihovnu přes Composer](README.md#instalace), můžete si
 stáhnout [poslední verzi v ZIP souboru](https://github.com/vyfakturuj/vyfakturuj-api-php/releases/latest).
 
 Tento ZIP rozbalte, tuto složku pak nahrajte do svého webu a následně na začátek vašeho projektu (nejčastěji `index.php`)

--- a/simple-autoload.php
+++ b/simple-autoload.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package Redbit\Vyfakturuj\VyfakturujAPI
+ * @license MIT
+ * @coypright 2016-2018 Redbit s.r.o.
+ * @author Redbit s.r.o. <info@vyfakturuj.cz>
+ * @author Ing. Martin Dostál
+ */
+
+/**
+ * Script pro ruční instalaci
+ * @see https://github.com/vyfakturuj/vyfakturuj-api-php/blob/master/manual-installation.md (Nápověda)
+ */
+spl_autoload_register(function ($class) {
+    $file = __DIR__ . '/libs/' . $class . '.class.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});

--- a/simple-autoload.php
+++ b/simple-autoload.php
@@ -2,7 +2,7 @@
 /**
  * @package Redbit\Vyfakturuj\VyfakturujAPI
  * @license MIT
- * @coypright 2016-2018 Redbit s.r.o.
+ * @copyright 2016-2018 Redbit s.r.o.
  * @author Redbit s.r.o. <info@vyfakturuj.cz>
  * @author Ing. Martin Dostál
  */


### PR DESCRIPTION
Částečně řeší #2 

Vylepšeno:
- dokumentace pro návod na správnou instalaci,
- přidán [simple-autoload.php](https://github.com/vyfakturuj/vyfakturuj-api-php/blob/c90050b377d826cb55c5cd829514767192604b91/simple-autoload.php), který řeší kolize knihoven,
- přidán [manual-installation.md](https://github.com/vyfakturuj/vyfakturuj-api-php/blob/c90050b377d826cb55c5cd829514767192604b91/README.md) s detailním popisem manuální instalace.

Prosím @pavel-janicek, jestli by se mohl podívat, zkusil si **[tuto verzi stáhnout](https://github.com/vyfakturuj/vyfakturuj-api-php/archive/c90050b377d826cb55c5cd829514767192604b91.zip)** a zkusit si to podle [toho návodu](https://github.com/vyfakturuj/vyfakturuj-api-php/blob/c90050b377d826cb55c5cd829514767192604b91/manual-installation.md) naistalovat.

Následně obdobně opravíme i WP plugin pro SimpleShop.