### PR TITLE
Lepší řešení SSL chyb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "php": ">=5.3.2",
         "ext-curl": "*",
         "ext-json": "*"
+    },
+    "suggest": {
+        "composer/ca-bundle": "Umožňuje ověřit SSL certifikáty serveru"
     }
 }

--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -406,9 +406,12 @@ class VyfakturujAPI
         curl_setopt($curl, CURLOPT_FAILONERROR, false);
         curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         curl_setopt($curl, CURLOPT_USERPWD, $this->login . ':' . $this->apiHash);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+
+        // Set SSL verification
+        $this->curlInjectCaCerts($curl);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
 
         switch ($method) {
             case self::HTTP_METHOD_POST:
@@ -436,6 +439,22 @@ class VyfakturujAPI
 
         $return = json_decode($response, true);
         return is_array($return) ? $return : $response;
+    }
+
+
+    /**
+     * @param resource $curl cURL handle
+     */
+    private function curlInjectCaCerts($curl)
+    {
+        if (class_exists('\Composer\CaBundle\CaBundle')) {
+            $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
+            if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+                curl_setopt($curl, CURLOPT_CAPATH, $caPathOrFile);
+            } else {
+                curl_setopt($curl, CURLOPT_CAINFO, $caPathOrFile);
+            }
+        }
     }
 
 

--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -48,6 +48,7 @@ class VyfakturujAPI
      *
      * @param array $data Data, která chceme použít při vytvoření.
      * @return array Vrátí kompletní informace o dokumentu
+     * @throws VyfakturujAPIException
      */
     public function createInvoice($data)
     {
@@ -61,6 +62,7 @@ class VyfakturujAPI
      * @param int $id ID dokumentu
      * @param array $data Data, která chceme upravit
      * @return array Vrátí kompletní informace o dokumentu
+     * @throws VyfakturujAPIException
      */
     public function updateInvoice($id, $data)
     {
@@ -73,6 +75,7 @@ class VyfakturujAPI
      *
      * @param int $id ID dokumentu
      * @return array Vrátí kompletní informace o dokumentu
+     * @throws VyfakturujAPIException
      */
     public function getInvoice($id)
     {
@@ -85,6 +88,7 @@ class VyfakturujAPI
      *
      * @param array $args Data pro vyhledání faktury
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function getInvoices($args = array())
     {
@@ -98,6 +102,7 @@ class VyfakturujAPI
      * @param int $id ID faktury
      * @param array $data Data, která chceme použít pro vytvoření šablony.
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function invoice_sendMail_test($id, $data)
     {
@@ -112,6 +117,7 @@ class VyfakturujAPI
      * @param int $id ID faktury
      * @param array $data Data, která chceme použít pro vytvoření e-mailu
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function invoice_sendMail($id, $data)
     {
@@ -124,6 +130,7 @@ class VyfakturujAPI
      *
      * @param int $id
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function invoice_sendEet($id)
     {
@@ -138,6 +145,7 @@ class VyfakturujAPI
      * @param string|null $date Např: 2016-12-31, pokud je nastaveno na 0000-00-00 pak se zruší uhrada dokladu
      * @param int|float $amount Kolik bylo uhrazeno. Pokud je NULL, bude faktura uhrazena nezávisle na částce
      * @return array Detail dokladu po uhrazeni
+     * @throws VyfakturujAPIException
      */
     public function invoice_setPayment($id, $date = null, $amount = null)
     {
@@ -154,6 +162,7 @@ class VyfakturujAPI
      *
      * @param int $id ID dokumentu
      * @return array Vrátí stav operace
+     * @throws VyfakturujAPIException
      */
     public function deleteInvoice($id)
     {
@@ -166,6 +175,7 @@ class VyfakturujAPI
      *
      * @param array $data Data, která chceme použít při vytvoření.
      * @return array Vrátí kompletní informace o kontaktu
+     * @throws VyfakturujAPIException
      */
     public function createContact($data)
     {
@@ -179,6 +189,7 @@ class VyfakturujAPI
      * @param int $id ID kontaktu
      * @param array $data Data, která chceme upravit
      * @return array Vrátí kompletní informace o kontaktu
+     * @throws VyfakturujAPIException
      */
     public function updateContact($id, $data)
     {
@@ -191,6 +202,7 @@ class VyfakturujAPI
      *
      * @param int $id ID kontaktu
      * @return array Vrátí kompletní informace o kontaktu
+     * @throws VyfakturujAPIException
      */
     public function getContact($id)
     {
@@ -203,6 +215,7 @@ class VyfakturujAPI
      *
      * @param array $args
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function getContacts($args = array())
     {
@@ -215,6 +228,7 @@ class VyfakturujAPI
      *
      * @param int $id ID kontaktu
      * @return array Vrátí stav operace
+     * @throws VyfakturujAPIException
      */
     public function deleteContact($id)
     {
@@ -227,6 +241,7 @@ class VyfakturujAPI
      *
      * @param array $data Data, která chceme použít při vytvoření.
      * @return array Vrátí kompletní informace o položce
+     * @throws VyfakturujAPIException
      */
     public function createTemplate($data)
     {
@@ -240,6 +255,7 @@ class VyfakturujAPI
      * @param int $id ID šablony|pravidelné faktury
      * @param array $data Data, která chceme upravit
      * @return array Vrátí kompletní informace o položce
+     * @throws VyfakturujAPIException
      */
     public function updateTemplate($id, $data)
     {
@@ -252,6 +268,7 @@ class VyfakturujAPI
      *
      * @param int $id ID šablony|pravidelné faktury
      * @return array Vrátí kompletní informace
+     * @throws VyfakturujAPIException
      */
     public function getTemplate($id)
     {
@@ -264,6 +281,7 @@ class VyfakturujAPI
      *
      * @param array $args Data pro vyhledání faktur
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function getTemplates($args = array())
     {
@@ -276,6 +294,7 @@ class VyfakturujAPI
      *
      * @param int $id ID šablony|pravidelné faktury
      * @return array Vrátí stav operace
+     * @throws VyfakturujAPIException
      */
     public function deleteTemplate($id)
     {
@@ -288,6 +307,7 @@ class VyfakturujAPI
      *
      * @param array $args Data pro vyhledání faktur
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function getProducts($args = array())
     {
@@ -299,6 +319,7 @@ class VyfakturujAPI
      * Vrati seznam platebních metod
      *
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function getSettings_paymentMethods()
     {
@@ -310,6 +331,7 @@ class VyfakturujAPI
      * Vrati seznam číselných řad
      *
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function getSettings_numberSeries()
     {
@@ -321,6 +343,7 @@ class VyfakturujAPI
      * Testovací funkce pro ověření správného spojení se serverem
      *
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function test()
     {
@@ -335,6 +358,7 @@ class VyfakturujAPI
      *
      * @param array $data
      * @return array
+     * @throws VyfakturujAPIException
      */
     public function test_invoice__asPdf($data)
     {
@@ -358,6 +382,7 @@ class VyfakturujAPI
 
     /**
      * Vrati informace o poslednim spojeni
+     *
      * @return array|null
      */
     public function getInfo()
@@ -371,6 +396,7 @@ class VyfakturujAPI
      * @param $method
      * @param array|null $data
      * @return array|mixed
+     * @throws VyfakturujAPIException
      */
     private function fetchRequest($path, $method, $data = array())
     {
@@ -401,7 +427,13 @@ class VyfakturujAPI
         $response = curl_exec($curl);
         $this->lastInfo = curl_getinfo($curl);
         $this->lastInfo['dataSend'] = $data;
+
+        if (curl_errno($curl) !== 0) {
+            throw new VyfakturujAPIException(curl_error($curl), curl_errno($curl));
+        }
+
         curl_close($curl);
+
         $return = json_decode($response, true);
         return is_array($return) ? $return : $response;
     }
@@ -411,6 +443,7 @@ class VyfakturujAPI
      * @param $path
      * @param array|null $data
      * @return array|mixed
+     * @throws VyfakturujAPIException
      */
     private function fetchGet($path, $data = null)
     {
@@ -422,6 +455,7 @@ class VyfakturujAPI
      * @param $path
      * @param array|null $data
      * @return array|mixed
+     * @throws VyfakturujAPIException
      */
     private function fetchPost($path, $data = null)
     {
@@ -433,6 +467,7 @@ class VyfakturujAPI
      * @param $path
      * @param array|null $data
      * @return array|mixed
+     * @throws VyfakturujAPIException
      */
     private function fetchPut($path, $data = null)
     {
@@ -444,6 +479,7 @@ class VyfakturujAPI
      * @param $path
      * @param array|null $data
      * @return array|mixed
+     * @throws VyfakturujAPIException
      */
     private function fetchDelete($path, $data = null)
     {

--- a/libs/VyfakturujAPIException.class.php
+++ b/libs/VyfakturujAPIException.class.php
@@ -1,0 +1,5 @@
+<?php
+
+class VyfakturujAPIException extends \RuntimeException
+{
+}


### PR DESCRIPTION
> Navazuje na #1, řeší #7 

BC break: Ano, při chybě spojení vyhazuje výjimku.

**Toto PR řeší 2 věci:**
1. Při chybě spojení došlo k tiché chybě, ze které nebylo možné zjistit příčinu.
2. Pokud na serveru nebyly správné SSL certifikáty, nebylo možné se bezpečně připojit.

**Vyhození výjimky:**
Při chybě spojení knihovna vyhodí výjimku [`VyfakturujAPIException`](https://github.com/vyfakturuj/vyfakturuj-api-php/blob/8526d5f5d9e3bef2c9a8d51a76aca8a580b695d5/libs/VyfakturujAPIException.class.php), ve které jsou předány chyby knihovny cURL. 

Výjimka se nevyhodí při chybě serveru, nebo pokud např. server vrátí status: 401. Pouze při závažných chybách v připojení.

Je to ovšem BC break – při chybě může shodit aplikaci, takže zvýší majoritní číslo knihovny na verzi `2.2.0`.

**SSL certifikáty:**
Mnoho serverů, ve kterých knihovna poběží, má problém se SSL certifikáty. Dosud knihovna neměla žádnou možnost, jak si poradit s takovou situací. Nyní stačí nainstalovat do aplikace [CA Bundle](https://github.com/composer/ca-bundle) a knihovna si sama naháhne správné certifikáty.

Instalace CA Bundlu není povinná, aplikace funguje i bez něho.