### PR TITLE
Vylepšení vzhledu a přehlednosti příkladů

### DIFF
--- a/examples/00-config.php
+++ b/examples/00-config.php
@@ -2,6 +2,7 @@
 
 // Načtení knihoven
 require_once __DIR__ . '/../simple-autoload.php';
+require_once __DIR__ . '/assets/example-layout.php';
 
 // Nastavení Vyfakturuj API
 define('VYFAKTURUJ_API_LOGIN', '');  // E-mail, kterým se přihlašujete do Vyfakturuj

--- a/examples/00-config.php
+++ b/examples/00-config.php
@@ -1,10 +1,17 @@
 <?php
 
-// Načtení knihoven
+/*
+ * Interní nastavení nezbytné pro běh příkladů
+ */
 require_once __DIR__ . '/../simple-autoload.php';
 require_once __DIR__ . '/assets/example-layout.php';
+if (!defined('JSON_PRETTY_PRINT')) {
+    define('JSON_PRETTY_PRINT', 128); // PHP 5.3 compatibility
+}
 
-// Nastavení Vyfakturuj API
+/* ================================================================
+ * Nastavení Vyfakturuj API - níže prosím vyplňte váš e-mail a klíč
+ */
 define('VYFAKTURUJ_API_LOGIN', '');  // E-mail, kterým se přihlašujete do Vyfakturuj
 define('VYFAKTURUJ_API_KEY', '');    // API klíč, který najdete v Nastavení -> API
 

--- a/examples/01-test.php
+++ b/examples/01-test.php
@@ -2,12 +2,9 @@
 
 require_once __DIR__ . '/00-config.php';
 
-$vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
+echo "<h2>Test připojení k serveru</h2>\n";
 
+$vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 $result = $vyfakturuj_api->test();
 
-echo '<h2>Test připojení k serveru:</h2>';
-echo '<pre>' . print_r($result, true) . '</pre>';
-
-
-exit;
+echo '<pre><code class="json">' . json_encode($result, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/02-invoice.php
+++ b/examples/02-invoice.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Vytvoření a úpravy faktury</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 #
@@ -57,8 +59,8 @@ $opt = array(
 
 $inv = $vyfakturuj_api->createInvoice($opt);    // vytvoříme novou fakturu
 //$inv = $vyfakturuj_api->invoice_setPayment($inv['id']);    // vytvoříme novou fakturu
-echo '<h2>Vytvořili jsme fakturu:</h2>';
-echo '<pre>' . print_r($inv, true) . '</pre>';
+echo '<h5>Vytvořili jsme fakturu:</h5>';
+echo '<pre><code class="json">' . json_encode($inv, JSON_PRETTY_PRINT) . '</code></pre>';
 $_ID_DOKUMENTU = $inv['id'];    // uložíme si ID nového dokumentu
 die;
 $opt = array(
@@ -68,8 +70,8 @@ $opt = array(
 );
 
 $inv = $vyfakturuj_api->createInvoice($opt);    // vytvoříme novou fakturu
-echo '<h2>Vytvořili jsme ODD:</h2>';
-echo '<pre>' . print_r($inv, true) . '</pre>';
+echo '<h5>Vytvořili jsme ODD:</h5>';
+echo '<pre><code class="json">' . json_encode($inv, JSON_PRETTY_PRINT) . '</code></pre>';
 $_ID_DOKUMENTU = $inv['id'];    // uložíme si ID nového dokumentu
 die;
 #
@@ -97,8 +99,8 @@ $opt = array(
 
 $inv2 = $vyfakturuj_api->updateInvoice($_ID_DOKUMENTU, $opt);    // upravíme fakturu
 
-echo '<h2>Upravili jsme fakturu:</h2>';
-echo '<pre>' . print_r($inv2, true) . '</pre>';
+echo '<h5>Upravili jsme fakturu:</h5>';
+echo '<pre><code class="json">' . json_encode($inv2, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -116,8 +118,8 @@ echo '<pre>' . print_r($inv2, true) . '</pre>';
 
 $inv3 = $vyfakturuj_api->getInvoice($_ID_DOKUMENTU);
 
-echo '<h2>Načetli jsme data o faktuře ze systému:</h2>';
-echo '<pre>' . print_r($inv3, true) . '</pre>';
+echo '<h5>Načetli jsme data o faktuře ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($inv3, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -136,6 +138,5 @@ exit;   // zablokování smazání
 
 $inv4 = $vyfakturuj_api->deleteInvoice($_ID_DOKUMENTU);
 
-echo '<h2>Načetli jsme data o průběhu smazání faktury ze systému:</h2>';
-echo '<pre>' . print_r($inv4, true) . '</pre>';
-exit;
+echo '<h5>Načetli jsme data o průběhu smazání faktury ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($inv4, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/03-contact.php
+++ b/examples/03-contact.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Vytvoření a úpravy kontaktu</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 #
@@ -31,8 +33,8 @@ $opt = array(
 
 $contact = $vyfakturuj_api->createContact($opt);    // vytvoříme novou fakturu
 
-echo '<h2>Vytvořili jsme kontakt:</h2>';
-echo '<pre>' . print_r($contact, true) . '</pre>';
+echo '<h5>Vytvořili jsme kontakt:</h5>';
+echo '<pre><code class="json">' . json_encode($contact, JSON_PRETTY_PRINT) . '</code></pre>';
 
 $_ID_KONTAKTU = $contact['id'];    // uložíme si ID nového kontaktu
 #
@@ -53,8 +55,8 @@ $opt = array(
 
 $contact2 = $vyfakturuj_api->updateContact($_ID_KONTAKTU, $opt);    // upravíme kontakt
 
-echo '<h2>Upravili jsme fakturu:</h2>';
-echo '<pre>' . print_r($contact2, true) . '</pre>';
+echo '<h5>Upravili jsme fakturu:</h5>';
+echo '<pre><code class="json">' . json_encode($contact2, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -73,8 +75,8 @@ echo '<pre>' . print_r($contact2, true) . '</pre>';
 $contact3 = $vyfakturuj_api->getContact($_ID_KONTAKTU); // načte 1 konkrétní kontakt
 // $contact3 = $vyfakturuj_api->getContacts();  // vrátí všechny moje kontakty
 
-echo '<h2>Načetli jsme data o kontaktu ze systému:</h2>';
-echo '<pre>' . print_r($contact3, true) . '</pre>';
+echo '<h5>Načetli jsme data o kontaktu ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($contact3, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -93,8 +95,5 @@ exit;   // zablokování smazání
 
 $contact4 = $vyfakturuj_api->deleteContact($_ID_KONTAKTU);
 
-echo '<h2>Načetli jsme data o průběhu smazání kontaktu ze systému:</h2>';
-echo '<pre>' . print_r($contact4, true) . '</pre>';
-
-
-exit;
+echo '<h5>Načetli jsme data o průběhu smazání kontaktu ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($contact4, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/04-template.php
+++ b/examples/04-template.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Vytvoření a úpravy šablony</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 #
@@ -61,8 +63,8 @@ $opt_template = array(
 
 $ret = $vyfakturuj_api->createTemplate($opt_template);    // vytvoříme novou fakturu
 
-echo '<h2>Vytvořili jsme pravidelnou fakturu:</h2>';
-echo '<pre>' . print_r($ret, true) . '</pre>';
+echo '<h5>Vytvořili jsme pravidelnou fakturu:</h5>';
+echo '<pre><code class="json">' . json_encode($ret, JSON_PRETTY_PRINT) . '</code></pre>';
 
 $_ID_ITEM = $ret['id'];    // uložíme si ID nového zaznamu
 #
@@ -95,8 +97,8 @@ $opt_template = array(
 
 $ret2 = $vyfakturuj_api->updateTemplate($_ID_ITEM, $opt_template);    // upravíme zaznam
 
-echo '<h2>Upravili jsme pravidelnou fakturu:</h2>';
-echo '<pre>' . print_r($ret2, true) . '</pre>';
+echo '<h5>Upravili jsme pravidelnou fakturu:</h5>';
+echo '<pre><code class="json">' . json_encode($ret2, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -116,8 +118,8 @@ $ret3 = $vyfakturuj_api->getTemplate($_ID_ITEM);
 // $ret3 = $vyfakturuj_api->getTemplates(); // vrati vsechny sablony a pravidelné faktury
 // $ret3 = $vyfakturuj_api->getTemplates(array('type' => 2,'end_type' => 1)); // vrati vsechny pravidelné faktury, které nemají nastaveno datum ukončení
 
-echo '<h2>Načetli jsme data o pravidelné faktuře faktuře ze systému:</h2>';
-echo '<pre>' . print_r($ret3, true) . '</pre>';
+echo '<h5>Načetli jsme data o pravidelné faktuře faktuře ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($ret3, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -136,7 +138,7 @@ exit;   // zablokování smazání
 $ret4 = $vyfakturuj_api->deleteTemplate($_ID_ITEM);
 $ret5 = $vyfakturuj_api->deleteContact($_ID_CONTACT);
 
-echo '<h2>Načetli jsme data o průběhu smazání faktury ze systému:</h2>';
-echo '<pre>' . print_r($ret4, true) . '</pre>';
-echo '<pre>' . print_r($ret5, true) . '</pre>';
-exit;
+echo '<h5>Načetli jsme data o průběhu smazání faktury ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($ret4, JSON_PRETTY_PRINT) . '</code></pre>';
+echo '<h5>Načetli jsme data o průběhu smazání kontaktu ze systému:</h5>';
+echo '<pre><code class="json">' . json_encode($ret5, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/05-invoice-sendMail.php
+++ b/examples/05-invoice-sendMail.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Odeslání e-mailu</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 #
@@ -36,8 +38,8 @@ $opt = array(// šablona, kterou si přejeme odeslat
 
 $res = $vyfakturuj_api->invoice_sendMail_test($_ID_DOKUMENTU, $opt);    // Získáme šablonu, co by se odeslalo
 
-echo '<h2>Tento mail by se odeslal:</h2>';
-echo '<pre>' . print_r($res, true) . '</pre>';
+echo '<h5>Tento mail by se odeslal:</h5>';
+echo '<pre><code class="json">' . json_encode($res, JSON_PRETTY_PRINT) . '</code></pre>';
 
 
 #
@@ -55,7 +57,5 @@ die('<span style="color:red">Odkomentujte řádek ' . __LINE__ . ' pokud chcete 
 
 $res = $vyfakturuj_api->invoice_sendMail($_ID_DOKUMENTU, $opt);    // Odešleme e-mail
 
-echo '<h2>Tento e-mail byl odeslán:</h2>';
-echo '<pre>' . print_r($res, true) . '</pre>';
-
-exit;
+echo '<h5>Tento e-mail byl odeslán:</h5>';
+echo '<pre><code class="json">' . json_encode($res, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/06-invoice-setPayment.php
+++ b/examples/06-invoice-setPayment.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Provedení uhrazení dokladu</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 
@@ -23,7 +25,5 @@ $_DATUM_UHRADY = '2016-07-25';
 
 $res = $vyfakturuj_api->invoice_setPayment($_ID_DOKUMENTU, $_DATUM_UHRADY);  // Provedeme uhrazení
 
-echo '<h2>Doklad po uhrazení:</h2>';
-echo '<pre>' . print_r($res, true) . '</pre>';
-
-exit;
+echo '<h5>Doklad po uhrazení:</h5>';
+echo '<pre><code class="json">' . json_encode($res, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/07-test-invoice-download.php
+++ b/examples/07-test-invoice-download.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Stažení faktury v PDF</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 $opt = array(
@@ -33,8 +35,5 @@ $opt = array(
 
 $result = $vyfakturuj_api->test_invoice__asPdf($opt);
 
-echo '<h2>Nepodařilo se stáhnout PDF:</h2>';
-echo '<pre>' . print_r($result, true) . '</pre>';
-
-
-exit;
+echo '<h5>Nepodařilo se stáhnout PDF:</h5>';
+echo '<pre><code class="json">' . json_encode($result, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/08-invoice-sendEET.php
+++ b/examples/08-invoice-sendEET.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Odeslání EET</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 
@@ -21,7 +23,5 @@ $_ID_DOKUMENTU = $_GET['id'];
 
 $res = $vyfakturuj_api->invoice_sendEet($_ID_DOKUMENTU);    // Odešleme e-mail
 
-echo '<h2>Tento dokument byl odeslán do EET:</h2>';
-echo '<pre>' . print_r($res, true) . '</pre>';
-
-exit;
+echo '<h5>Tento dokument byl odeslán do EET:</h5>';
+echo '<pre><code class="json">' . json_encode($res, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/09-invoice_search.php
+++ b/examples/09-invoice_search.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Vyhledání faktur</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 /*
@@ -19,8 +21,5 @@ $opt = array(
 
 $inv = $vyfakturuj_api->getInvoices($opt);
 
-echo '<h2>Načetli jsme tyto doklady:</h2>';
-echo '<pre>' . print_r($inv, true) . '</pre>';
-
-
-exit;
+echo '<h5>Načetli jsme tyto doklady:</h5>';
+echo '<pre><code class="json">' . json_encode($inv, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/10-product.php
+++ b/examples/10-product.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Vyhledání produktů</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 $opt = array(
@@ -12,8 +14,5 @@ $opt = array(
 
 $ret = $vyfakturuj_api->getProducts($opt);
 
-echo '<h2>Načetli jsme tyto produkty:</h2>';
-echo '<pre>' . print_r($ret, true) . '</pre>';
-
-
-exit;
+echo '<h5>Načetli jsme tyto produkty:</h5>';
+echo '<pre><code class="json">' . json_encode($ret, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/11-payment-method.php
+++ b/examples/11-payment-method.php
@@ -2,12 +2,11 @@
 
 require_once __DIR__ . '/00-config.php';
 
+echo "<h2>Načtení platebních metod</h2>\n";
+
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 $inv = $vyfakturuj_api->getSettings_paymentMethods();
 
-echo '<h2>Načetli jsme tyto data:</h2>';
-echo '<pre>' . print_r($inv, true) . '</pre>';
-
-
-exit;
+echo '<h5>Načetli jsme tyto data:</h5>';
+echo '<pre><code class="json">' . json_encode($inv, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/12-number-series.php
+++ b/examples/12-number-series.php
@@ -1,13 +1,11 @@
 <?php
 
 require_once __DIR__ . '/00-config.php';
+echo "<h2>Číselné řady</h2>\n";
 
 $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
 
 $inv = $vyfakturuj_api->getSettings_numberSeries();
 
-echo '<h2>Načetli jsme tyto data:</h2>';
-echo '<pre>' . print_r($inv, true) . '</pre>';
-
-
-exit;
+echo '<h5>Načetli jsme tyto data:</h5>';
+echo '<pre><code class="json">' . json_encode($inv, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/examples/assets/example-layout.php
+++ b/examples/assets/example-layout.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @package Redbit\Vyfakturuj\VyfakturujAPI
+ * @license MIT
+ * @copyright 2016-2018 Redbit s.r.o.
+ * @author Redbit s.r.o. <info@vyfakturuj.cz>
+ * @author Ing. Martin Dostál
+ */
+
+
+/**
+ * Tento soubor není pro běh API důležitý, pouze pomáhá zlepšit přehlednost ukázek
+ */
+$web = PHP_SAPI !== 'cli';
+
+if ($web):
+    ?>
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha256-eSi1q2PG6J7g7ib17yAaWMcrr5GrtohYChqibrV7PBE=" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-light.min.css" integrity="sha256-aw9uGjVU5OJyMYN70Vu2kZ1DDVc1slcJCS2XvuPCPKo=" crossorigin="anonymous">
+        <link rel="shortcut icon" href="https://www.vyfakturuj.cz/favicon.ico">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.slim.min.js" integrity="sha256-3edrmyuQ0w65f8gfBsqowzjJe2iM6n0nKciPUp8y+7E=" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha256-VsEqElsCHSGmnmHXGQzvoWjWwoznFSZc6hs7ARLRacQ=" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" integrity="sha256-/BfiIkHlHoVihZdc6TFuj7MmJ0TWcWsMXkeDFwhi0zw=" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/json.min.js" integrity="sha256-KPdGtw3AdDen/v6+9ue/V3m+9C2lpNiuirroLsHrJZM=" crossorigin="anonymous"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
+        <title>VyfakturujAPI - příklady</title>
+    </head>
+    <body>
+        <div class="container">
+            <h1 class="mt-5"><a href="https://www.vyfakturuj.cz/api/">VyfakturujAPI</a> příklad</h1>
+            <div class="jumbotron mt-3">
+    <?php
+endif;
+
+
+register_shutdown_function(function () use ($web) {
+    if ($web) :
+        ?>
+
+            </div>
+        </div>
+    </body>
+</html>
+        <?php
+    else:
+        echo PHP_EOL;
+    endif;
+});
+
+
+set_exception_handler(function ($e) use ($web) {
+    /**
+     * For compatibility PHP 5.3 - 7.2+ unable to type parameter directly
+     * @var \Throwable $e
+     */
+    if ($web) :
+        ?>
+
+        <div class="alert alert-danger" role="alert">
+            <strong><?= sprintf('Došlo k chybě #%d (%s):', $e->getCode(), get_class($e)); ?></strong>
+            <code style="display:block;white-space: pre-wrap"><?= $e->getMessage(); ?></code>
+            <small><?= sprintf('na řádku %d v souboru: <code>%s</code>', $e->getLine(), $e->getFile()); ?></small>
+        </div>
+    <?php
+    else:
+        // Use system handler
+        return false;
+    endif;
+});
+
+
+set_error_handler(function ($errno, $errstr, $errfile, $errline) use ($web) {
+    $style = 'danger';
+    $name = 'Fatální chyba';
+
+    switch ($errno) {
+        case E_WARNING:
+        case E_CORE_WARNING:
+        case E_COMPILE_WARNING:
+        case E_USER_WARNING:
+            $style = 'warning';
+            $name = 'Varování';
+            break;
+        case E_NOTICE:
+        case E_USER_NOTICE:
+            $style = 'warning';
+            $name = 'Upozornění';
+            break;
+        case E_STRICT:
+            $style = 'secondary';
+            $name = 'Upozornění (strict)';
+    }
+
+    if ($web) :
+        ?>
+
+            <div class="alert alert-<?= $style ;?>" role="alert">
+                <strong><?= sprintf('%s:', $name); ?></strong>
+                <code style="display:block;white-space: pre-wrap"><?= $errstr; ?></code>
+                <small><?= sprintf('na řádku %d v souboru: <code>%s</code>', $errline, $errfile); ?></small>
+            </div>
+        <?php
+    else:
+        // Use system handler
+        return false;
+    endif;
+});


### PR DESCRIPTION
Vylepšil jsem přehlednost příkladů a to s minimálním zásahem do příkladů samotných.

V příkladech se změnily pouze úrovně a umístění nadpisů a místo `print_r()` se používá výpis do JSONu, který má navíc obarvenou syntaxi.

Předchozí vzhled:
![image](https://user-images.githubusercontent.com/1657322/45021067-eb748180-b030-11e8-8e67-b794d4021cf5.png)


Navržený vzhled:
![image](https://user-images.githubusercontent.com/1657322/45021059-e3b4dd00-b030-11e8-9005-3a95b01503ed.png)

Zpracování chyb a výjimek:
![image](https://user-images.githubusercontent.com/1657322/45021347-9f760c80-b031-11e8-9c96-04df8f657879.png)

Z části se myslí i na použití v terminálu – zde se většina HTML nevykresluje:
![image](https://user-images.githubusercontent.com/1657322/45021522-16130a00-b032-11e8-99eb-9b9b08526928.png)
