### PR TITLE
Examples: Add error handling (#13)

### DIFF
--- a/examples/13-error-handle.php
+++ b/examples/13-error-handle.php
@@ -33,6 +33,9 @@ try {
     // Vypíšeme uživateli omluvu, že se nepodařilo jeho požadavek dokončit
     // Uživatele nezatěžujeme technickými detaily, ty nechme technikovi
     echo "<div class=\"alert alert-danger\">Je nám líto, ale při zpracování došlo k chybě. Zkuste to prosím později, nebo nás kontaktujte.</div>\n";
+
+    // Technikovi zapíšeme chybu do logů, aby věděl, co se děje
+    trigger_error($e, E_USER_WARNING);
 }
 
 // Aplikace pokračuje dál

--- a/examples/13-error-handle.php
+++ b/examples/13-error-handle.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once __DIR__ . '/00-config.php';
+
+
+
+// Pomocná třída pro ukázku, která je záměrně poškozená, aby selhala
+class VyfakturujBrokenAPI extends VyfakturujAPI
+{
+    protected $endpointUrl = 'https://invalid.domain.vyfakturuj.cz/2.0/';
+}
+
+
+
+/*
+ * Níže je ukázka, která je stejná jako v souboru 01-test.php, nicméně je záměrně poškozena, aby skončila chybou.
+ * V příkladu je simulována situace, kdy se nepodaří připojení na API, například z důvodu vypadku internetu.
+ * Při takové chybě dojde k tomu, že kód v daném místě „umře“ a nepokračuje dál, což by mohlo rozbít vaši aplikaci.
+ * Tím, že kód zabalíte do try {...} catch, umožníte chybu tzv. zachytit, ošetřit a pokračovat v aplikaci dál.
+ */
+
+
+try {
+    // Ukázka stejná, jako v příkladu 01-test.php
+    echo "<h2>Ošetření chyb</h2>\n";
+
+    $vyfakturuj_api = new VyfakturujBrokenAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
+    $result = $vyfakturuj_api->test();
+
+    echo '<pre><code class="json">' . json_encode($result, JSON_PRETTY_PRINT) . '</code></pre>';
+} catch (VyfakturujAPIException $e) {
+    // Toto se spustí, pokud kdekoliv v try {...} dojde k chybě (tzv. výjimce)
+    // Vypíšeme uživateli omluvu, že se nepodařilo jeho požadavek dokončit
+    // Uživatele nezatěžujeme technickými detaily, ty nechme technikovi
+    echo "<div class=\"alert alert-danger\">Je nám líto, ale při zpracování došlo k chybě. Zkuste to prosím později, nebo nás kontaktujte.</div>\n";
+}
+
+// Aplikace pokračuje dál
+echo '<p>Pokračování aplikace…</p>';

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,3 +67,8 @@ Ukázka, jak získat seznam platebních metod (způsobů uhrady).
 > Soubor: [12-number-series.php](12-number-series.php)
 
 Ukázka, jak získat seznam číslených řad.
+
+### 13. Ošetření chyb
+> Soubor: [13-error-handle.php](13-error-handle.php)
+
+Ukázka, jak ošetřit chyby, které mohou při použití knihovny vzniknout.


### PR DESCRIPTION
Doplnil jsem nový příklad popisující, jak správně a jednoduše ošetřit chybu, která by mohla rozbít aplikaci, do které je API knihovna vložena.

Pro jednoduchost tam není nijak pořešeno logování, takže ošetřením se ztrácí informace o příčinách. Není to dobře, ještě zvažuji přidání řádku s [`triger_error()`](http://php.net/manual/en/function.trigger-error.php):

```php
...
} catch (VyfakturujAPIException $e) {
    echo "Je nám líto, došlo k chybě. ...\n";
    triger_error($e, E_USER_WARNING);
}
...
```