### PR TITLE
Strict comparator instead of is_null()

### DIFF
--- a/src/VyfakturujApi.php
+++ b/src/VyfakturujApi.php
@@ -153,8 +153,8 @@ class VyfakturujApi
      */
     public function invoice_setPayment($id, $date = null, $amount = null)
     {
-        $data = array('date' => is_null($date) ? date('Y-m-d') : $date);
-        if (!is_null($amount)) {
+        $data = array('date' => $date === null ? date('Y-m-d') : $date);
+        if ($amount !== null) {
             $data['amount'] = $amount;
         }
         return $this->fetchPost('invoice/' . $id . '/payment/', $data);


### PR DESCRIPTION
`is_null()` není striktní a může pohtit i některé ne-`null`ové hodnoty. Převedeno na `===`.

BC break: Možná, ale krajně nepravděpodobné. Nicméně odloženo do verze 3.0.