### PR TITLE
Unification private -> protected

### DIFF
--- a/src/VyfakturujApi.php
+++ b/src/VyfakturujApi.php
@@ -412,7 +412,7 @@ class VyfakturujApi
      * @return array|mixed
      * @throws VyfakturujApiException
      */
-    private function fetchRequest($path, $method, $data = array())
+    protected function fetchRequest($path, $method, $data = array())
     {
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $this->endpointUrl . $path);
@@ -466,7 +466,7 @@ class VyfakturujApi
     /**
      * @param resource $curl cURL handle
      */
-    private function curlInjectCaCerts($curl)
+    protected function curlInjectCaCerts($curl)
     {
         if (class_exists('\Composer\CaBundle\CaBundle')) {
             $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();


### PR DESCRIPTION
Sjednocení viditelnosti z `private` na `protected`.

Private nemůže být použito, už třeba kvůli příkladu 13. Rozdělení private/protected nemá smysl, sjednocení dává smysl.

BC break: ne