### PR TITLE
Curl: Allow API connection compression

### DIFF
--- a/src/VyfakturujApi.php
+++ b/src/VyfakturujApi.php
@@ -423,6 +423,10 @@ class VyfakturujApi
         curl_setopt($curl, CURLOPT_USERPWD, $this->login . ':' . $this->apiHash);
         curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
 
+        if(defined('CURLOPT_ENCODING')) { // PHP < 7.1 compatibility
+            curl_setopt($curl, CURLOPT_ENCODING, '');
+        }
+
         // Set SSL verification
         $this->curlInjectCaCerts($curl);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);


### PR DESCRIPTION
Povolení komprese přenášených dat. U JSONu může být gzip komprese >50%. 

BC break: Ne