### PR TITLE
Add getter+setter for EndpointUrl

### DIFF
--- a/examples/13-error-handle.php
+++ b/examples/13-error-handle.php
@@ -3,15 +3,6 @@
 require_once __DIR__ . '/00-config.php';
 
 
-
-// Pomocná třída pro ukázku, která je záměrně poškozená, aby selhala
-class VyfakturujBrokenAPI extends VyfakturujAPI
-{
-    protected $endpointUrl = 'https://invalid.domain.vyfakturuj.cz/2.0/';
-}
-
-
-
 /*
  * Níže je ukázka, která je stejná jako v souboru 01-test.php, nicméně je záměrně poškozena, aby skončila chybou.
  * V příkladu je simulována situace, kdy se nepodaří připojení na API, například z důvodu vypadku internetu.
@@ -24,7 +15,11 @@ try {
     // Ukázka stejná, jako v příkladu 01-test.php
     echo "<h2>Ošetření chyb</h2>\n";
 
-    $vyfakturuj_api = new VyfakturujBrokenAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
+    $vyfakturuj_api = new VyfakturujAPI(VYFAKTURUJ_API_LOGIN, VYFAKTURUJ_API_KEY);
+
+    // Úprava URL pro ukázku, která je záměrně poškozená, aby selhala
+    $vyfakturuj_api->setEndpointUrl('https://invalid.domain.vyfakturuj.cz/2.0/');
+
     $result = $vyfakturuj_api->test();
 
     echo '<pre><code class="json">' . json_encode($result, JSON_PRETTY_PRINT) . '</code></pre>';

--- a/libs/VyfakturujAPI.class.php
+++ b/libs/VyfakturujAPI.class.php
@@ -509,4 +509,28 @@ class VyfakturujAPI
         return $this->fetchRequest($path, self::HTTP_METHOD_DELETE, $data);
     }
 
+    /**
+     * @return string
+     */
+    public function getEndpointUrl()
+    {
+        return $this->endpointUrl;
+    }
+
+    /**
+     * @param string $endpointUrl
+     * @throws VyfakturujAPIException
+     */
+    public function setEndpointUrl($endpointUrl)
+    {
+        if(preg_match('~https?://~i', $endpointUrl) !== 1) {
+            throw new VyfakturujAPIException(sprintf(
+                'Endpoint URL must be a valid absolute URL on HTTP(S) protocol, \'%s\' is not valid absolute URL',
+                $endpointUrl
+            ));
+        }
+
+        $this->endpointUrl = $endpointUrl;
+    }
+
 }


### PR DESCRIPTION
PR přidává nový getter a setter pro změnu URL, na kterou se knihovna připojuje. Současně setter testuje, že je URL absolutní HTTP(S) adresa.

V souboru `example/13-error-handle.php` je právě uvedený příklad, který dědičnost používal. Tento soubor byl tedy v rámci PR upraven, aby používal nové rozhraní.


## Důvod
Potřebujeme mít možnost pro účely testování změnit URL endpoint, pak se client připojuje. Tato potřeba již vznikla dříve, ale řešila se nevhodně poděděním třídy na jinou upravenou, která dané URL přepisuje dedičností – to je ale velmi neefektivní a neudržitelné.



